### PR TITLE
Fix shorthand numeric property parsing bug

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -12,6 +12,8 @@ Object {
   "h1": Object {
     "fontSize": 32,
   },
+  "left": -1,
   "margin": 32,
+  "padding": "6px 9px",
 }
 `;

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ const camel = str => str
   .replace(/(-[a-z])/g, x => x.toUpperCase())
   .replace(/-/g, '')
 
-const parsePx = val => /px$/.test(val)
-  ? parseFloat(val.replace(/px$/, ''))
+const parsePx = val => /^-?\d+px$/.test(val)
+  ? parseFloat(val)
   : val
 
 module.exports = toObj

--- a/test.js
+++ b/test.js
@@ -67,6 +67,8 @@ test('snapshot', t => {
   const obj = toObj(`
     color: tomato;
     margin: 32px;
+    padding: 6px 9px;
+    left: -1px;
     @media (min-width: 40em) {
       margin: 48px;
     }


### PR DESCRIPTION
Very minor but I noticed  `margin: 1em 40px` was getting incorrectly smooshed into `margin: 1` by `parsePx`. This PR adds a digit check to the regex test.
